### PR TITLE
Sampling over both env and denoising steps in DPPO updates

### DIFF
--- a/agent/finetune/train_ppo_diffusion_agent.py
+++ b/agent/finetune/train_ppo_diffusion_agent.py
@@ -285,40 +285,46 @@ class TrainPPODiffusionAgent(TrainPPOAgent):
                     )
                 }
                 chains_k = einops.rearrange(
-                    torch.tensor(chains_trajs).float().to(self.device),
+                    torch.tensor(chains_trajs, device=self.device).float(),
                     "s e t h d -> (s e) t h d",
                 )
                 returns_k = (
-                    torch.tensor(returns_trajs).float().to(self.device).reshape(-1)
+                    torch.tensor(returns_trajs, device=self.device).float().reshape(-1)
                 )
                 values_k = (
-                    torch.tensor(values_trajs).float().to(self.device).reshape(-1)
+                    torch.tensor(values_trajs, device=self.device).float().reshape(-1)
                 )
                 advantages_k = (
-                    torch.tensor(advantages_trajs).float().to(self.device).reshape(-1)
+                    torch.tensor(advantages_trajs, device=self.device)
+                    .float()
+                    .reshape(-1)
                 )
-                logprobs_k = torch.tensor(logprobs_trajs).float().to(self.device)
+                logprobs_k = torch.tensor(logprobs_trajs, device=self.device).float()
 
                 # Update policy and critic
-                total_steps = self.n_steps * self.n_envs
-                inds_k = np.arange(total_steps)
+                total_steps = self.n_steps * self.n_envs * self.model.ft_denoising_steps
+                inds_k = torch.randperm(total_steps, device=self.device)
                 clipfracs = []
                 for update_epoch in range(self.update_epochs):
 
                     # for each epoch, go through all data in batches
                     flag_break = False
-                    np.random.shuffle(inds_k)
                     num_batch = max(1, total_steps // self.batch_size)  # skip last ones
                     for batch in range(num_batch):
                         start = batch * self.batch_size
                         end = start + self.batch_size
                         inds_b = inds_k[start:end]  # b for batch
-                        obs_b = {"state": obs_k["state"][inds_b]}
-                        chains_b = chains_k[inds_b]
-                        returns_b = returns_k[inds_b]
-                        values_b = values_k[inds_b]
-                        advantages_b = advantages_k[inds_b]
-                        logprobs_b = logprobs_k[inds_b]
+                        batch_inds_b, denoising_inds_b = torch.unravel_index(
+                            inds_b,
+                            (self.n_steps * self.n_envs, self.model.ft_denoising_steps),
+                        )
+                        obs_b = {"state": obs_k["state"][batch_inds_b]}
+                        chains_prev_b = chains_k[batch_inds_b, denoising_inds_b]
+                        chains_next_b = chains_k[batch_inds_b, denoising_inds_b + 1]
+                        returns_b = returns_k[batch_inds_b]
+                        values_b = values_k[batch_inds_b]
+                        advantages_b = advantages_k[batch_inds_b]
+                        logprobs_b = logprobs_k[batch_inds_b, denoising_inds_b]
 
                         # get loss
                         (
@@ -332,7 +338,9 @@ class TrainPPODiffusionAgent(TrainPPOAgent):
                             eta,
                         ) = self.model.loss(
                             obs_b,
-                            chains_b,
+                            chains_prev_b,
+                            chains_next_b,
+                            denoising_inds_b,
                             returns_b,
                             values_b,
                             advantages_b,

--- a/model/diffusion/diffusion_ppo.py
+++ b/model/diffusion/diffusion_ppo.py
@@ -81,7 +81,7 @@ class PPODiffusion(VPGDiffusion):
         reward_horizon: action horizon that backpropagates gradient
         """
         # Get new logprobs for denoising steps from T-1 to 0 - entropy is fixed fod diffusion
-        newlogprobs, eta = self.get_logprobs(
+        newlogprobs, eta, denoising_indices = self.get_logprobs_subsample(
             obs,
             chains,
             get_ent=True,
@@ -90,9 +90,12 @@ class PPODiffusion(VPGDiffusion):
         newlogprobs = newlogprobs.clamp(min=-5, max=2)
         oldlogprobs = oldlogprobs.clamp(min=-5, max=2)
 
+        # Index oldlogprobs with sampled indices
+        oldlogprobs = oldlogprobs[torch.arange(len(oldlogprobs)), denoising_indices]
+
         # only backpropagate through the earlier steps (e.g., ones actually executed in the environment)
         newlogprobs = newlogprobs[:, :reward_horizon, :]
-        oldlogprobs = oldlogprobs[:, :, :reward_horizon, :]
+        oldlogprobs = oldlogprobs[:, :reward_horizon, :]
 
         # Get the logprobs - batch over B and denoising steps
         newlogprobs = newlogprobs.mean(dim=(-1, -2)).view(-1)
@@ -133,14 +136,13 @@ class PPODiffusion(VPGDiffusion):
         advantage_max = torch.quantile(advantages, self.clip_advantage_upper_quantile)
         advantages = advantages.clamp(min=advantage_min, max=advantage_max)
 
-        # repeat advantages for denoising steps and horizon steps
-        advantages = advantages.repeat_interleave(self.ft_denoising_steps)
-
         # denoising discount
         discount = torch.tensor(
-            [self.gamma_denoising**i for i in reversed(range(self.ft_denoising_steps))]
+            [
+                self.gamma_denoising ** (self.ft_denoising_steps - i - 1)
+                for i in denoising_indices
+            ]
         ).to(self.device)
-        discount = discount.repeat(len(advantages) // self.ft_denoising_steps)
         advantages *= discount
 
         # get ratio
@@ -148,9 +150,7 @@ class PPODiffusion(VPGDiffusion):
         ratio = logratio.exp()
 
         # exponentially interpolate between the base and the current clipping value over denoising steps and repeat
-        t = torch.arange(self.ft_denoising_steps).float().to(self.device) / (
-            self.ft_denoising_steps - 1
-        )  # 0 to 1
+        t = (denoising_indices.float() / (self.ft_denoising_steps - 1)).to(self.device)
         if self.ft_denoising_steps > 1:
             clip_ploss_coef = self.clip_ploss_coef_base + (
                 self.clip_ploss_coef - self.clip_ploss_coef_base
@@ -158,10 +158,7 @@ class PPODiffusion(VPGDiffusion):
                 math.exp(self.clip_ploss_coef_rate) - 1
             )
         else:
-            clip_ploss_coef = torch.tensor([self.clip_ploss_coef]).to(self.device)
-        clip_ploss_coef = clip_ploss_coef.repeat(
-            len(advantages) // self.ft_denoising_steps
-        )
+            clip_ploss_coef = t
 
         # get kl difference and whether value clipped
         with torch.no_grad():

--- a/model/diffusion/diffusion_vpg.py
+++ b/model/diffusion/diffusion_vpg.py
@@ -395,6 +395,87 @@ class VPGDiffusion(DiffusionModel):
             return log_prob, eta
         return log_prob
 
+    def get_logprobs_subsample(
+        self,
+        cond,
+        chains,
+        get_ent: bool = False,
+        use_base_policy: bool = False,
+    ):
+        """
+        Calculating the logprobs of random samples of denoised chains.
+
+        Args:
+            cond: dict with key state/rgb; more recent obs at the end
+                state: (B, To, Do)
+                rgb: (B, To, C, H, W)
+            chains: (B, K+1, Ta, Da)
+            get_ent: flag for returning entropy
+            use_base_policy: flag for using base policy
+
+        Returns:
+            logprobs: (B, Ta, Da)
+            entropy (if get_ent=True):  (B, Ta)
+            denoising_indices: (B, )
+        """
+        B = len(chains)
+
+        # # Repeat cond for denoising_steps, flatten batch and time dimensions
+        # cond = {
+        #     key: cond[key]
+        #     .unsqueeze(1)
+        #     .repeat(1, self.ft_denoising_steps, *(1,) * (cond[key].ndim - 1))
+        #     .flatten(start_dim=0, end_dim=1)
+        #     for key in cond
+        # }  # less memory usage than einops?
+
+        # Sample t for batch dim, keep it 1-dim
+        if self.use_ddim:
+            t_single = self.ddim_t[-self.ft_denoising_steps :]
+        else:
+            t_single = torch.arange(
+                start=self.ft_denoising_steps - 1,
+                end=-1,
+                step=-1,
+                device=self.device,
+            )
+            # 4,3,2,1,0,4,3,2,1,0,...,4,3,2,1,0
+        denoising_indices = torch.randint(
+            low=0, high=self.ft_denoising_steps, size=(B,)
+        )
+        t_all = t_single[denoising_indices]
+        if self.use_ddim:
+            ddim_indices_single = torch.arange(
+                start=self.ddim_steps - self.ft_denoising_steps,
+                end=self.ddim_steps,
+                device=self.device,
+            )  # only used for DDIM
+            ddim_indices = ddim_indices_single[denoising_indices]
+        else:
+            ddim_indices = None
+
+        # Index chains
+        chains_prev = chains[torch.arange(B), denoising_indices]
+        chains_next = chains[torch.arange(B), denoising_indices + 1]
+
+        # Forward pass with previous chains
+        next_mean, logvar, eta = self.p_mean_var(
+            chains_prev,
+            t_all,
+            cond=cond,
+            index=ddim_indices,
+            use_base_policy=use_base_policy,
+        )
+        std = torch.exp(0.5 * logvar)
+        std = torch.clip(std, min=self.min_logprob_denoising_std)
+        dist = Normal(next_mean, std)
+
+        # Get logprobs with gaussian
+        log_prob = dist.log_prob(chains_next)
+        if get_ent:
+            return log_prob, eta, denoising_indices
+        return log_prob, denoising_indices
+
     def loss(self, cond, chains, reward):
         """
         REINFORCE loss. Not used right now.


### PR DESCRIPTION
Previously DPPO update samples env steps with each one including the entire chain of denoising steps, instead of sampling over both env step and denoising step. Sampling over both improves DPPO performance.

Need to update DPPO configs